### PR TITLE
fix/392-cost-coverage-curve-does-not-update

### DIFF
--- a/client/source/js/modules/common/save-graph-as-directive.js
+++ b/client/source/js/modules/common/save-graph-as-directive.js
@@ -52,6 +52,8 @@ define(['angular', 'jquery', 'underscore', 'saveAs', './svg-to-png'],
 
                 } else if (attrs.variant == 'coGraph') {
                   target = scope.coGraph;
+                } else if (attrs.variant == 'ccGraph') {
+                  target = scope.ccGraph;
                 } else {
                   target= scope.graph;
                 }

--- a/client/source/js/modules/common/save-graph-as-directive.js
+++ b/client/source/js/modules/common/save-graph-as-directive.js
@@ -286,7 +286,7 @@ define(['angular', 'jquery', 'underscore', 'saveAs', './svg-to-png'],
             if(!graphOrUndefined) { return scope.saySorry();}
             var exportable = this.getExportableFrom(graphOrUndefined);
             if(exportable === null) { return scope.saySorry(); }
-            var title = graphOrUndefined.options.title || graphOrUndefined.title;
+            var title = graphOrUndefined.options.title || graphOrUndefined.title || "data";
             $http({url:'/api/project/export',
                   method:'POST',
                   data: exportable,

--- a/client/source/js/modules/model/cost-coverage-ctrl.js
+++ b/client/source/js/modules/model/cost-coverage-ctrl.js
@@ -195,6 +195,8 @@ define(['./module', 'underscore'], function (module, _) {
     var prepareGraphsOfType = function (data, type) {
       if (type === 'plotdata_cc') {
         $scope.graphs[type] = prepareCostCoverageGraph(data);
+        $scope.ccGraph =  $scope.graphs[type];
+        $scope.ccGraph.title = $scope.displayedProgram.name;
       } else if (type === 'plotdata' || type === 'plotdata_co') {
         _(data).each(function (graphData) {
           $scope.graphs[type].push(setUpPlotdataGraph(graphData));

--- a/client/source/js/modules/model/cost-coverage-ctrl.js
+++ b/client/source/js/modules/model/cost-coverage-ctrl.js
@@ -187,15 +187,16 @@ define(['./module', 'underscore'], function (module, _) {
     };
 
     /**
-     * Receives graphs data with plot type to calculate,
-     * calculates all graphs of given type and writes them to $scope.graphs[type]
+     * Receives graphs data with plot type to calculate, calculates all graphs
+     * of given type and writes them to $scope.graphs[type] except for the
+     * cost coverage graph which will be written to $scope.ccGraph
+     *
      * @param data - usually api request with graphs data
      * @param type - string
      */
     var prepareGraphsOfType = function (data, type) {
       if (type === 'plotdata_cc') {
-        $scope.graphs[type] = prepareCostCoverageGraph(data);
-        $scope.ccGraph =  $scope.graphs[type];
+        $scope.ccGraph = prepareCostCoverageGraph(data);
         $scope.ccGraph.title = $scope.displayedProgram.name;
       } else if (type === 'plotdata' || type === 'plotdata_co') {
         _(data).each(function (graphData) {

--- a/client/source/js/modules/model/cost-coverage.html
+++ b/client/source/js/modules/model/cost-coverage.html
@@ -41,8 +41,8 @@
     <div class="section" ng-if="hasCostCoverResponse">
       <h1>{{ displayedProgram.name }}</h1>
       <div class="section elastic" style="width: 470px">
-        <div class="chart-container" ng-init="graph = graphs.plotdata_cc; graph.title = displayedProgram.name">
-          <div line-scatter-chart data="graph.data" options="graph.options" save-graph-as></div>
+        <div class="chart-container">
+          <div line-scatter-chart variant="ccGraph" data="ccGraph.data" options="ccGraph.options" save-graph-as></div>
         </div>
       </div>
 


### PR DESCRIPTION
 cost-coverage-ctrl.js and cost-coverage.html:
- Bind the cc graph to a new scope variable "ccGraph" explicitly when preparing the graph data (instead in an ng-init as previously), enabling scope.$watch to function properly (for data and options) in the lineScatterDirective

save-graph-as-directive.js:
 - Implement new variant "ccGraph"