### PR TITLE
358-there-is-no-feedback-from-the-app-when-click-on-export-data-in-ff34-0

### DIFF
--- a/client/source/js/modules/common/save-graph-as-directive.js
+++ b/client/source/js/modules/common/save-graph-as-directive.js
@@ -293,8 +293,11 @@ define(['angular', 'jquery', 'underscore', 'saveAs', './svg-to-png'],
                   headers: {'Content-type': 'application/json'},
                   responseType:'arraybuffer'})
               .success(function (response, status, headers, config) {
-                var blob = new Blob([response], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
-                saveAs(blob, (title+'.xlsx'));
+                  var blob = new Blob([response], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+                  // The saveAs function must be wrapped in a setTimeout with 0 ms because Angular has a problem with fileSaver.js on FF 34.0 and the download doesn't start
+                  setTimeout(function() {
+                    saveAs(blob, (title+'.xlsx'));
+                  }, 0);
               })
               .error(function () {});
           };


### PR DESCRIPTION
save-graph-as-directive.js: fix saving xlsx files on ff 34 