### PR TITLE
feature/420-make-the-cost-coverage-outcome-graphs-update-as-soon-as-the-parameter-values-are-changed-i-e-don-t-require-users-to-click-draw-a

### DIFF
--- a/client/source/js/modules/common/save-graph-as-directive.js
+++ b/client/source/js/modules/common/save-graph-as-directive.js
@@ -65,7 +65,7 @@ define(['angular', 'jquery', 'underscore', 'saveAs', './svg-to-png'],
           scope.exportAll = function () {
             var graphs = [];
             var controller = scope.exportGraphs.controller;
-            
+
             // Optimization
             if ( controller == 'AnalysisOptimization' ) {
 
@@ -85,7 +85,7 @@ define(['angular', 'jquery', 'underscore', 'saveAs', './svg-to-png'],
               }
             }
 
-            // Calibration 
+            // Calibration
             // Analysis Scenarios
             if ( controller == 'ModelCalibration' || controller == 'AnalysisScenarios' ) {
               if ( scope.graphs ) {
@@ -94,7 +94,7 @@ define(['angular', 'jquery', 'underscore', 'saveAs', './svg-to-png'],
             }
 
             // Cost Coverage
-            if ( controller == 'ModelViewCalibration' ) {
+            if ( controller == 'ModelCostCoverage' ) {
               if (scope.ccGraph) {
                 graphs.push(scope.ccGraph);
               }
@@ -285,7 +285,7 @@ define(['angular', 'jquery', 'underscore', 'saveAs', './svg-to-png'],
           };
 
           /**
-           * Returns the normalized data ready for export 
+           * Returns the normalized data ready for export
            * for Radar Chart
            */
           scope.axesExport = function (graph){
@@ -358,7 +358,7 @@ define(['angular', 'jquery', 'underscore', 'saveAs', './svg-to-png'],
            */
           scope.exportMultiSheetFrom = function (graphs){
             if(graphs.length == 0) { return scope.saySorry("Sorry, no graphs found");}
-            
+
             var exportables = [];
             var showAlert = false;
             _(graphs).each(function (graph, index) {

--- a/client/source/js/modules/model/cost-coverage-ctrl.js
+++ b/client/source/js/modules/model/cost-coverage-ctrl.js
@@ -56,7 +56,7 @@ define(['./module', 'underscore'], function (module, _) {
         if(!categories) { // create default categories if absent
           categories = [];
           _.times(meta.progs.long.length, function (n){
-            categories.push('Others')
+            categories.push('Others');
           });}
 
         return {
@@ -290,7 +290,7 @@ define(['./module', 'underscore'], function (module, _) {
       // validation on Cost-coverage curve plotting options
       if ( !$scope.areValidParams(model.ccparams) ){
         modalService.inform(
-          function (){ null },
+          function () {},
           'Okay',
           $scope.optionsErrorMessage,
           'Error!'
@@ -326,7 +326,7 @@ define(['./module', 'underscore'], function (module, _) {
 
     $scope.changeProgram = function() {
       $scope.hasCostCoverResponse = false;
-    }
+    };
 
     /**
      * Retrieve and update graphs based on the current plot models.
@@ -343,7 +343,7 @@ define(['./module', 'underscore'], function (module, _) {
     $scope.uploadDefault = function () {
       var message = 'Upload default cost-coverage-outcome curves will be available in a future version of Optima. We are working hard in make it happen for you!';
       modalService.inform(
-        function (){ null },
+        function () {},
         'Okay',
         message,
         'Thanks for your interest!'
@@ -389,7 +389,7 @@ define(['./module', 'underscore'], function (module, _) {
       model.effect =  effectNames[graphIndex];
       if ( !$scope.areValidParams(model.coparams) ){
         modalService.inform(
-          function (){ null },
+          function () {},
           'Okay',
           $scope.optionsErrorMessage,
           'Error!'

--- a/client/source/js/modules/model/cost-coverage-ctrl.js
+++ b/client/source/js/modules/model/cost-coverage-ctrl.js
@@ -17,7 +17,7 @@ define(['./module', 'underscore'], function (module, _) {
       // show message "calibrate the model" and disable the form elements
       $scope.projectInfo = info;
       $scope.needData = !$scope.projectInfo.has_data;
-      
+
       if ( !$scope.needData ) {
         $scope.initializePrograms();
         $scope.selectedProgram = $scope.programs[0];
@@ -28,7 +28,7 @@ define(['./module', 'underscore'], function (module, _) {
         $scope.hasCostCoverResponse = false;
 
       }
-      
+
       // model parameters
       $scope.defaultSaturationCoverageLevel = 90;
       $scope.defaultKnownCoverageLevel = 20;
@@ -38,6 +38,7 @@ define(['./module', 'underscore'], function (module, _) {
       $scope.behaviorWithoutMax = 0.5;
       $scope.behaviorWithMin = 0.7;
       $scope.behaviorWithMax = 0.9;
+      $scope.curvesInitialized = false;
 
       plotTypes = ['plotdata', 'plotdata_cc', 'plotdata_co'];
 
@@ -57,7 +58,7 @@ define(['./module', 'underscore'], function (module, _) {
           _.times(meta.progs.long.length, function (n){
             categories.push('Others')
           });}
-          
+
         return {
           name: name,
           acronym: meta.progs.short[index],
@@ -261,14 +262,14 @@ define(['./module', 'underscore'], function (module, _) {
       if ( !model.ccparams[0] || !model.ccparams[1] || !model.ccparams[2] || !model.ccparams[3] ){
         var message = 'Cost-coverage curve plotting options cannot be empty!';
         modalService.inform(
-          function (){ null }, 
+          function (){ null },
           'Okay',
-          message, 
+          message,
           'Error!'
-        ); 
+        );
         return;
       }
-      
+
       /**
        * stop further execution and return in case of null selectedProgram
        */
@@ -301,6 +302,7 @@ define(['./module', 'underscore'], function (module, _) {
      * Retrieve and update graphs based on the current plot models.
      */
     $scope.generateCurves = function () {
+      $scope.curvesInitialized = true;
       var model = getPlotModel();
       retrieveAndUpdateGraphs(model);
     };
@@ -308,11 +310,11 @@ define(['./module', 'underscore'], function (module, _) {
     $scope.uploadDefault = function () {
       var message = 'Upload default cost-coverage-outcome curves will be available in a future version of Optima. We are working hard in make it happen for you!';
       modalService.inform(
-        function (){ null }, 
+        function (){ null },
         'Okay',
-        message, 
+        message,
         'Thanks for your interest!'
-      );      
+      );
     };
 
     /**
@@ -359,6 +361,16 @@ define(['./module', 'underscore'], function (module, _) {
         $scope.graphs.plotdata_co[graphIndex] = setUpPlotdataGraph(response.plotdata_co);
       });
     };
+
+    /**
+     * Retrieve and update graphs based on the current plot models only if the graphs are already rendered
+     * by pressing the draw button.
+     */
+    $scope.updateCurves =  _.debounce(function() { // debounce a bit so we don't update immediately
+      if($scope.curvesInitialized === true) {
+       $scope.generateCurves();
+      }
+    }, 500);
 
     initialize();
 

--- a/client/source/js/modules/model/cost-coverage-ctrl.spec.coffee
+++ b/client/source/js/modules/model/cost-coverage-ctrl.spec.coffee
@@ -1,0 +1,64 @@
+define ['angular-mocks', 'Source/modules/model/cost-coverage-ctrl'], ->
+  describe 'ModelCostCoverageController in app.model', ->
+    scope = null
+    subject = null
+
+    beforeEach ->
+      module 'app.model'
+
+      inject ($rootScope, $controller) ->
+        meta = {
+          "pops": {
+            "client": [ 0 ],
+            "female": [ 0 ],
+            "injects": [ 0 ],
+            "long": [ "Men who have sex with men" ],
+            "male": [ 1 ],
+            "sexmen": [ 0 ],
+            "sexwomen": [ 1 ],
+            "sexworker": [ 0 ],
+            "short": [ "MSM" ]
+          },
+          "progs": {
+            "currentbudget": [ 154000.00000000003 ],
+            "long": [ "Social and behavior change communication" ],
+            "saturating": [ 1 ],
+            "short": [ "SBCC" ]
+          }
+        }
+
+        scope = $rootScope.$new()
+        subject = $controller 'ModelCostCoverageController', {
+          $scope: scope
+          meta: meta
+          modalService: {}
+          info: {}
+        }
+
+    describe 'convertFromPercent()', ->
+
+      it 'should return a number divided by 100', ->
+        expect(scope.convertFromPercent(60)).toBe(0.6)
+        expect(scope.convertFromPercent(2)).toBe(0.02)
+        expect(scope.convertFromPercent(-33)).toBe(-0.33)
+
+      it 'should return NaN for anything else then a number', ->
+        expect(scope.convertFromPercent("60")).toBeNaN()
+        expect(scope.convertFromPercent(undefined)).toBeNaN()
+        expect(scope.convertFromPercent(null)).toBeNaN()
+
+    describe 'areValidParams()', ->
+
+      it 'should return true for an array containing NaN, undefined & null', ->
+        expect(scope.areValidParams([NaN, undefined, null])).toBeTruthy()
+        expect(scope.areValidParams([NaN, NaN])).toBeTruthy()
+        expect(scope.areValidParams([undefined])).toBeTruthy()
+        expect(scope.areValidParams([null])).toBeTruthy()
+
+      it 'should return true for an array containing only values', ->
+        expect(scope.areValidParams([1, 'wow', true])).toBeTruthy()
+        expect(scope.areValidParams([2, 54])).toBeTruthy()
+
+      it 'should return false for an array containing mixed values & NaN, undefined or null ', ->
+        expect(scope.areValidParams([NaN, undefined, null, 2])).toBeFalsy()
+        expect(scope.areValidParams([NaN, 'wow'])).toBeFalsy()

--- a/client/source/js/modules/model/cost-coverage.html
+++ b/client/source/js/modules/model/cost-coverage.html
@@ -31,6 +31,7 @@
         3. Specify the maximum funding (for plotting only):
         <input type="number" class="txbox __inline __xl" placeholder="e.g.{{defaultXAxisMaximum}}"  ng-model="xAxisMaximum" ng-change="updateCurves()">
       </p>
+      <span ng-show="!areValidParams(costCoverageParams()) && hasCostCoverResponse" class="error-hint">{{ optionsErrorMessage }}</span>
     </div>
 
     <div class="section">

--- a/client/source/js/modules/model/cost-coverage.html
+++ b/client/source/js/modules/model/cost-coverage.html
@@ -19,17 +19,17 @@
     <div class="section">
       <p>
         1. Specify the saturation coverage level:
-        <input type="number" class="txbox __inline __m" min="0" max="100" placeholder="e.g.{{defaultSaturationCoverageLevel}}" ng-model="saturationCoverageLevel">%
+        <input type="number" class="txbox __inline __m" min="0" max="100" placeholder="e.g.{{defaultSaturationCoverageLevel}}" ng-model="saturationCoverageLevel" ng-change="updateCurves()">%
       </p>
       <p>
         2. The estimated amount of funding needed to get
-        <input type="number" class="txbox __inline __m" min="0" max="100" placeholder="e.g.{{defaultKnownCoverageLevel}}" ng-model="knownCoverageLevel">%
+        <input type="number" class="txbox __inline __m" min="0" max="100" placeholder="e.g.{{defaultKnownCoverageLevel}}" ng-model="knownCoverageLevel" ng-change="updateCurves()">%
         coverage for this program is:
-        <input type="number" class="txbox __inline __xl" placeholder="e.g.{{defaultKnownFundingValue}}"  ng-model="knownFundingValue">
+        <input type="number" class="txbox __inline __xl" placeholder="e.g.{{defaultKnownFundingValue}}"  ng-model="knownFundingValue" ng-change="updateCurves()">
       </p>
       <p>
         3. Specify the maximum funding (for plotting only):
-        <input type="number" class="txbox __inline __xl" placeholder="e.g.{{defaultXAxisMaximum}}"  ng-model="xAxisMaximum">
+        <input type="number" class="txbox __inline __xl" placeholder="e.g.{{defaultXAxisMaximum}}"  ng-model="xAxisMaximum" ng-change="updateCurves()">
       </p>
     </div>
 

--- a/client/source/js/modules/model/module.js
+++ b/client/source/js/modules/model/module.js
@@ -2,6 +2,7 @@ define([
   'angular',
   'ui.router',
   '../resources/model',
+  '../resources/project',
   '../ui/type-selector/index',
   '../common/graph-type-factory'
 ], function (angular) {
@@ -42,7 +43,7 @@ define([
         })
         .state('model.define-cost-coverage-outcome', {
           url: '/define-cost-coverage-outcome',
-          controller: 'ModelViewCalibrationController',
+          controller: 'ModelCostCoverageController',
           templateUrl: 'js/modules/model/cost-coverage.html',
           resolve: {
             info: function(Project) {


### PR DESCRIPTION
https://trello.com/c/lDUwMMzJ/420-make-the-cost-coverage-outcome-graphs-update-as-soon-as-the-parameter-values-are-changed-i-e-don-t-require-users-to-click-draw-a

feat(graphs): Make the cost-coverate-outcome graphs update as soon as the parameter values are changed. Implemented using ng-change on the 4 text fields. Implemented a 500msec debounce using underscore. There is a ngModelOptions that debounces ng-model updates, but it's in angular versions >= 1.3. The graphs are updated only if they are initially rendered by selecting the 'Draw' button.