### PR TITLE
424-small-changes-so-the-project-could-be-also-used-with-node-sass-instead-of-ruby-sass

### DIFF
--- a/client/source/sass/main/base/_button.scss
+++ b/client/source/sass/main/base/_button.scss
@@ -2,7 +2,8 @@
 // ======
 
 .btn {
-  @extend .btn.__m, .btn.__blue;
+  @extend .btn.__m;
+  @extend .btn.__blue;
   border-radius: 3px;
   border-style: solid;
   border-width: 1px;

--- a/client/source/sass/main/base/layout/_grid.scss
+++ b/client/source/sass/main/base/layout/_grid.scss
@@ -1,9 +1,24 @@
 // Grid
 // ====
 
-$grid-columns: 12 !default;
+$grid-columns: (
+        '\31 ',
+        '\32 ',
+        '\33 ',
+        '\34 ',
+        '\35 ',
+        '\36 ',
+        '\37 ',
+        '\38 ',
+        '\39 ',
+        '\31 0',
+        '\31 1',
+        '\31 2',
+);
 
-$grid-column-width: (100% / $grid-columns);
+$grid-columns-length: length($grid-columns);
+
+$grid-column-width: (100% / $grid-columns-length);
 $grid-gutter-half: $layout-gutter / 2;
 
 .grid {
@@ -13,6 +28,7 @@ $grid-gutter-half: $layout-gutter / 2;
 }
 
 %grid-columns-all {
+
   float: left;
   min-height: 1px;
 
@@ -26,34 +42,37 @@ $grid-gutter-half: $layout-gutter / 2;
   position: relative;
 }
 
-@for $i from 1 through $grid-columns {
+@for $i from 1 through $grid-columns-length {
 
-  .#{escape-css($i)} {
+  $escaped: nth($grid-columns, $i);
+
+  .#{$escaped} {
     @extend %grid-columns-all;
     width: $i * $grid-column-width;
   }
 }
 
-@for $i from 1 to $grid-columns {
+@for $i from 1 to $grid-columns-length {
 
+  $escaped: nth($grid-columns, $i);
   $grid-current-column-width: $i * $grid-column-width;
 
-  .#{escape-css('++#{$i}')} {
+  .\+\+#{$i} {
     @extend %grid-columns-all;
     margin-left: $grid-current-column-width;
   }
 
-  .#{escape-css('#{$i}++')} {
+  .#{$escaped}\+\+ {
     @extend %grid-columns-all;
     margin-right: $grid-current-column-width;
   }
 
-  .#{escape-css('--#{$i}')} {
+  .\-\-#{$i} {
     @extend %grid-columns-push-pull;
     left: -$grid-current-column-width;
   }
 
-  .#{escape-css('#{$i}--')} {
+  .#{$escaped}\-\- {
     @extend %grid-columns-push-pull;
     left: $grid-current-column-width;
   }


### PR DESCRIPTION
_grid.scss is taken from the ng-seed repo (which now uses node-sass)
_button.scss has just one small change - splitting multiple extends in two lines

https://trello.com/c/dqXoN5wW/424-small-changes-so-the-project-could-be-also-used-with-node-sass-instead-of-ruby-sass