### PR TITLE
disabling cost-coverage functionality if run simulation was not called

### DIFF
--- a/client/source/js/modules/model/cost-coverage-ctrl.js
+++ b/client/source/js/modules/model/cost-coverage-ctrl.js
@@ -1,7 +1,7 @@
 define(['./module', 'underscore'], function (module, _) {
   'use strict';
 
-  module.controller('ModelCostCoverageController', function ($scope, $http, meta, info, modalService, programs) {
+  module.controller('ModelCostCoverageController', function ($scope, $http, $window, meta, info, modalService, programs) {
 
     var plotTypes, effectNames;
 
@@ -17,6 +17,8 @@ define(['./module', 'underscore'], function (module, _) {
       // show message "calibrate the model" and disable the form elements
       $scope.projectInfo = info;
       $scope.needData = !$scope.projectInfo.has_data;
+      $scope.cannotCalibrate = !$scope.projectInfo.can_calibrate
+      $scope.notReady = $scope.needData || $scope.cannotCalibrate;
 
       $scope.optionsErrorMessage = 'Cost-coverage curve plotting options should be either empty or all present.';
       $scope.all_programs = programs;
@@ -44,6 +46,13 @@ define(['./module', 'underscore'], function (module, _) {
       plotTypes = ['plotdata', 'plotdata_cc', 'plotdata_co'];
 
       resetGraphs();
+    };
+
+    /**
+     * Redirects the user to View & Calibrate screen.
+     */
+    $scope.gotoViewCalibrate = function() {
+      $window.location.href = '#/model/view';
     };
 
     /**

--- a/client/source/js/modules/model/cost-coverage-ctrl.js
+++ b/client/source/js/modules/model/cost-coverage-ctrl.js
@@ -1,7 +1,8 @@
 define(['./module', 'underscore'], function (module, _) {
   'use strict';
 
-  module.controller('ModelCostCoverageController', function ($scope, $http, $window, meta, info, modalService, programs) {
+  module.controller('ModelCostCoverageController', function ($scope, $http,
+    $state, meta, info, modalService, programs) {
 
     var plotTypes, effectNames;
 
@@ -17,7 +18,7 @@ define(['./module', 'underscore'], function (module, _) {
       // show message "calibrate the model" and disable the form elements
       $scope.projectInfo = info;
       $scope.needData = !$scope.projectInfo.has_data;
-      $scope.cannotCalibrate = !$scope.projectInfo.can_calibrate
+      $scope.cannotCalibrate = !$scope.projectInfo.can_calibrate;
       $scope.notReady = $scope.needData || $scope.cannotCalibrate;
 
       $scope.optionsErrorMessage = 'Cost-coverage curve plotting options should be either empty or all present.';
@@ -52,7 +53,7 @@ define(['./module', 'underscore'], function (module, _) {
      * Redirects the user to View & Calibrate screen.
      */
     $scope.gotoViewCalibrate = function() {
-      $window.location.href = '#/model/view';
+      $state.go('model.view');
     };
 
     /**

--- a/client/source/js/modules/model/cost-coverage.html
+++ b/client/source/js/modules/model/cost-coverage.html
@@ -1,8 +1,19 @@
 <div class="page rich">
 
-  <div class="section grid">
+  <div class="section grid" ng-show="notReady">
+      <div class="9">
+          <h1>Model is not ready</h1>
+          <div>
+              <p>This model is not yet ready to define cost-coverage assumptions.</p>
+              <button type="button" class="btn" ng-click="gotoViewCalibrate()">View &amp; calibrate model</button>
+          </div>
+      </div>
+  </div>
+
+  <div class="section grid" ng-hide="notReady">
     <div class="6">
       <p ng-show="needData" class="error-hint">Please upload Optima spreadsheet first.</p>
+      <p ng-show="cannotCalibrate" class="error-hint">Please run "View & calibrate" -> View simulation" first.</p>
       <label>
         Select a program: <br>
         <select
@@ -10,9 +21,8 @@
           ng-options="p as p.name group by p.category for p in programs"
           ng-change="changeProgram()"
           ng-model="selectedProgram"
-          ng-disabled="needData"></select>
+          ng-disabled="notReady"></select>
       </label>
-
     </div>
   </div>
   <div class="section" ng-hide="selectedProgram.acronym==null">

--- a/client/source/js/modules/model/cost-coverage.html
+++ b/client/source/js/modules/model/cost-coverage.html
@@ -4,16 +4,18 @@
       <div class="9">
           <h1>Model is not ready</h1>
           <div>
-              <p>This model is not yet ready to define cost-coverage assumptions.</p>
-              <button type="button" class="btn" ng-click="gotoViewCalibrate()">View &amp; calibrate model</button>
+              <p ng-show="needData" class="error-hint">Please upload Optima spreadsheet first.</p>
+
+              <div ng-show="cannotCalibrate && !needData">
+                <p class="error-hint">This model is not yet ready to define cost-coverage assumptions.</p>
+                <button type="button" class="btn" ng-click="gotoViewCalibrate()">View &amp; calibrate model</button>
+              </div>
           </div>
       </div>
   </div>
 
   <div class="section grid" ng-hide="notReady">
     <div class="6">
-      <p ng-show="needData" class="error-hint">Please upload Optima spreadsheet first.</p>
-      <p ng-show="cannotCalibrate" class="error-hint">Please run "View & calibrate" -> View simulation" first.</p>
       <label>
         Select a program: <br>
         <select
@@ -25,7 +27,7 @@
       </label>
     </div>
   </div>
-  <div class="section" ng-hide="selectedProgram.acronym==null">
+  <div class="section" ng-hide="selectedProgram.acronym == null">
     <div class="section">
       <p>
         1. Specify the saturation coverage level:


### PR DESCRIPTION
https://trello.com/c/rSJ3lltK/427-exception-when-click-draw-in-define-cost-coverage-without-view-simulation