### PR TITLE
layout changes to cost-coverage curves

### DIFF
--- a/client/source/js/modules/model/cost-coverage-ctrl.js
+++ b/client/source/js/modules/model/cost-coverage-ctrl.js
@@ -94,13 +94,13 @@ define(['./module', 'underscore'], function (module, _) {
 
     var getLineScatterOptions = function (options, xLabel, yLabel) {
       var defaults = {
-        height: 300,
-        width: 450,
+        width: 300,
+        height: 200,
         margin: {
           top: 20,
-          right: 20,
-          bottom: 60,
-          left: 100
+          right: 5,
+          bottom: 40,
+          left: 60
         },
         xAxis: {
           axisLabel: xLabel || 'X'

--- a/client/source/js/modules/model/cost-coverage-ctrl.js
+++ b/client/source/js/modules/model/cost-coverage-ctrl.js
@@ -17,7 +17,7 @@ define(['./module', 'underscore'], function (module, _) {
       $scope.cannotCalibrate = !$scope.projectInfo.can_calibrate;
       $scope.notReady = $scope.needData || $scope.cannotCalibrate;
 
-      $scope.optionsErrorMessage = 'Cost-coverage curve plotting options should be either empty or all present.';
+      $scope.optionsErrorMessage = 'To define a cost-coverage curve, values must be provided in the first three text boxes.';
       $scope.all_programs = programs;
 
       if ( !$scope.needData ) {

--- a/client/source/js/modules/model/cost-coverage.html
+++ b/client/source/js/modules/model/cost-coverage.html
@@ -44,7 +44,7 @@
 
       <h1>{{ displayedProgram.name }}</h1>
       <div class="section elastic">
-        <div class="elastic_col __shrink" style="width: 300px">
+        <div class="elastic_col __shrink">
           <div class="chart-container">
             <div line-scatter-chart variant="ccGraph" data="ccGraph.data" options="ccGraph.options" save-graph-as></div>
           </div>

--- a/client/source/js/modules/model/cost-coverage.html
+++ b/client/source/js/modules/model/cost-coverage.html
@@ -62,11 +62,11 @@
               <input type="number" class="txbox __inline __xl" placeholder="e.g.{{defaultKnownFundingValue}}"  ng-model="knownFundingValue" ng-change="updateCurves()">
             </p>
             <p>
-              3. Specify scale-up parameters:
+              3. [Optional] Specify scale-up parameters:
               <input type="number" class="txbox __inline __xl" placeholder="e.g.{{defaultScaleUpParameter}}"  ng-model="scaleUpParameter" ng-change="updateCurves()">
             </p>
             <p>
-              4. Full coverage would avert
+              4. [Optional] Full coverage would avert
               <input type="number" class="txbox __inline __xl" placeholder="e.g.{{defaultNonHivDalys}}"  ng-model="nonHivDalys" ng-change="updateCurves()">
               non-HIV-related DALYs per year
             </p>

--- a/client/source/js/modules/model/cost-coverage.html
+++ b/client/source/js/modules/model/cost-coverage.html
@@ -22,7 +22,6 @@
           class="txbox"
           ng-options="p as p.name group by p.category for p in programs"
           ng-change="changeProgram()"
-          ng-click="generateCurves()"
           ng-model="selectedProgram"
           ng-disabled="notReady"></select>
       </label>

--- a/client/source/js/modules/model/cost-coverage.html
+++ b/client/source/js/modules/model/cost-coverage.html
@@ -1,17 +1,17 @@
 <div class="page rich">
 
   <div class="section grid" ng-show="notReady">
-      <div class="9">
-          <h1>Model is not ready</h1>
-          <div>
-              <p ng-show="needData" class="error-hint">Please upload Optima spreadsheet first.</p>
+    <div class="9">
+      <h1>Model is not ready</h1>
+      <div>
+        <p ng-show="needData" class="error-hint">Please upload Optima spreadsheet first.</p>
 
-              <div ng-show="cannotCalibrate && !needData">
-                <p class="error-hint">This model is not yet ready to define cost-coverage assumptions.</p>
-                <button type="button" class="btn" ng-click="gotoViewCalibrate()">View &amp; calibrate model</button>
-              </div>
-          </div>
+        <div ng-show="cannotCalibrate && !needData">
+          <p class="error-hint">This model is not yet ready to define cost-coverage assumptions.</p>
+          <button type="button" class="btn" ng-click="gotoViewCalibrate()">View &amp; calibrate model</button>
+        </div>
       </div>
+    </div>
   </div>
 
   <div class="section grid" ng-hide="notReady">
@@ -22,34 +22,13 @@
           class="txbox"
           ng-options="p as p.name group by p.category for p in programs"
           ng-change="changeProgram()"
+          ng-click="generateCurves()"
           ng-model="selectedProgram"
           ng-disabled="notReady"></select>
       </label>
     </div>
   </div>
   <div class="section" ng-hide="selectedProgram.acronym == null">
-    <div class="section">
-      <p>
-        1. Specify the saturation coverage level:
-        <input type="number" class="txbox __inline __m" min="0" max="100" placeholder="e.g.{{defaultSaturationCoverageLevel}}" ng-model="saturationCoverageLevel" ng-change="updateCurves()">%
-      </p>
-      <p>
-        2. The estimated amount of funding needed to get
-        <input type="number" class="txbox __inline __m" min="0" max="100" placeholder="e.g.{{defaultKnownCoverageLevel}}" ng-model="knownCoverageLevel" ng-change="updateCurves()">%
-        coverage for this program is:
-        <input type="number" class="txbox __inline __xl" placeholder="e.g.{{defaultKnownFundingValue}}"  ng-model="knownFundingValue" ng-change="updateCurves()">
-      </p>
-      <p>
-        3. Specify scale-up parameters:
-        <input type="number" class="txbox __inline __xl" placeholder="e.g.{{defaultScaleUpParameter}}"  ng-model="scaleUpParameter" ng-change="updateCurves()">
-      </p>
-      <p>
-        4. Full coverage would avert
-        <input type="number" class="txbox __inline __xl" placeholder="e.g.{{defaultNonHivDalys}}"  ng-model="nonHivDalys" ng-change="updateCurves()">
-        non-HIV-related DALYs per year
-      </p>
-      <span ng-show="!hasValidCCParams()" class="error-hint">{{ optionsErrorMessage }}</span>
-    </div>
 
     <div class="section">
       <button type="button" class="btn" ng-click="generateCurves()">Draw</button>
@@ -65,26 +44,48 @@
 
       <h1>{{ displayedProgram.name }}</h1>
       <div class="section elastic">
-        <div class="elastic_col __shrink" style="width: 470px">
+        <div class="elastic_col __shrink" style="width: 300px">
           <div class="chart-container">
             <div line-scatter-chart variant="ccGraph" data="ccGraph.data" options="ccGraph.options" save-graph-as></div>
           </div>
         </div>
         <div class="elastic_col">
+          <div class="section">
+            <p>
+              1. Specify the saturation coverage level:
+              <input type="number" class="txbox __inline __m" min="0" max="100" placeholder="e.g.{{defaultSaturationCoverageLevel}}" ng-model="saturationCoverageLevel" ng-change="updateCurves()">%
+            </p>
+            <p>
+              2. The estimated amount of funding needed to get
+              <input type="number" class="txbox __inline __m" min="0" max="100" placeholder="e.g.{{defaultKnownCoverageLevel}}" ng-model="knownCoverageLevel" ng-change="updateCurves()">%
+              coverage for this program is:
+              <input type="number" class="txbox __inline __xl" placeholder="e.g.{{defaultKnownFundingValue}}"  ng-model="knownFundingValue" ng-change="updateCurves()">
+            </p>
+            <p>
+              3. Specify scale-up parameters:
+              <input type="number" class="txbox __inline __xl" placeholder="e.g.{{defaultScaleUpParameter}}"  ng-model="scaleUpParameter" ng-change="updateCurves()">
+            </p>
+            <p>
+              4. Full coverage would avert
+              <input type="number" class="txbox __inline __xl" placeholder="e.g.{{defaultNonHivDalys}}"  ng-model="nonHivDalys" ng-change="updateCurves()">
+              non-HIV-related DALYs per year
+            </p>
+            <span ng-show="!hasValidCCParams()" class="error-hint">{{ optionsErrorMessage }}</span>
+          </div>
           <p>
-        Specify the maximum funding (for plotting only):
-        <input type="number" class="txbox __inline __xl" placeholder="e.g.{{defaultXAxisMaximum}}"  ng-model="$parent.xAxisMaximum" ng-change="updateCurves()">
+            5. Specify the maximum funding (for plotting only):
+            <input type="number" class="txbox __inline __xl" placeholder="e.g.{{defaultXAxisMaximum}}"  ng-model="$parent.xAxisMaximum" ng-change="updateCurves()">
           </p>
           <p>
-          <label>
-            <input type="radio" name="displaycost" ng-model="$parent.displayCost" value="1" ng-change="updateCurves()">
-            Display program cost data in current prices
-          </label><br>
-          <label>
-            <input type="radio" name="displaycost" ng-model="$parent.displayCost" value="2" ng-change="updateCurves()">
-            Display program cost data in
-            <input class="txbox __inline __l" placeholder="e.g. 2014" ng-model="$parent.displayYear" min="projectInfo.dataStart" max="projectInfo.dataEnd" ng-change="updateCurves()"> prices
-          </label>
+            <label>
+              <input type="radio" name="displaycost" ng-model="$parent.displayCost" value="1" ng-change="updateCurves()">
+              Display program cost data in current prices
+            </label><br>
+            <label>
+              <input type="radio" name="displaycost" ng-model="$parent.displayCost" value="2" ng-change="updateCurves()">
+              Display program cost data in
+              <input class="txbox __inline __l" placeholder="e.g. 2014" ng-model="$parent.displayYear" min="projectInfo.dataStart" max="projectInfo.dataEnd" ng-change="updateCurves()"> prices
+            </label>
           </p>
           <p ng-show="$parent.displayCost == 2 && !$parent.displayYear" class="error-hint">Please specify year for program cost data.</p>
 


### PR DESCRIPTION
One thing to fix before it's merged: can you make the first (cost-coverage) graph smaller? I tried changing the container from 470px to 300px but I think I changed the wrong thing since the container is actually 590px wide. I'm not an FE person :)