### PR TITLE
feat(scale): use 3 decimal points for ranges between min/max lower than ...

### DIFF
--- a/client/source/js/modules/d3-charts/scale-helpers.js
+++ b/client/source/js/modules/d3-charts/scale-helpers.js
@@ -65,17 +65,21 @@ define(['d3'], function (d3) {
    * For a range smaller than 0.01 a precesion of 3 decimal points is chosen.
    * For a range smaller than 1 a precesion of 2 decimal points is chosen.
    * For a range smaller than 10 a precesion of 1 decimal points is chosen.
-   * For a range between 10 & 100,000 a precesion of 0 decimal points is chosen.
+   * For a range between 10 & 10,000 a precesion of 0 decimal points is chosen.
+   * For a range between 10,000 & 100,000 a precesion of 0 decimal points is
+   * chosen with a comma as thousands separator.
    * For a range larger than 100,000 the numbers are custom suffixed.
    */
   var evaluateTickFormat = function(min, max) {
     var range = Math.abs(max) - Math.abs(min);
     if (range < 0.01) {
-      return ',.3f';
+      return '.3f';
     } else if (range < 1) {
-      return ',.2f';
+      return '.2f';
     } else if (range < 10) {
-      return ',.1f';
+      return '.1f';
+    } else if (range < 10000) {
+      return '.0f';
     } else if (range > 100000) {
       return 'custom';
     } else {

--- a/client/source/js/modules/d3-charts/scale-helpers.js
+++ b/client/source/js/modules/d3-charts/scale-helpers.js
@@ -62,6 +62,7 @@ define(['d3'], function (d3) {
   /**
    * Returns an appropriate tick format depending on the range of the values.
    *
+   * For a range smaller than 0.01 a precesion of 3 decimal points is chosen.
    * For a range smaller than 1 a precesion of 2 decimal points is chosen.
    * For a range smaller than 10 a precesion of 1 decimal points is chosen.
    * For a range between 10 & 100,000 a precesion of 0 decimal points is chosen.
@@ -69,7 +70,9 @@ define(['d3'], function (d3) {
    */
   var evaluateTickFormat = function(min, max) {
     var range = Math.abs(max) - Math.abs(min);
-    if (range < 1) {
+    if (range < 0.01) {
+      return ',.3f';
+    } else if (range < 1) {
       return ',.2f';
     } else if (range < 10) {
       return ',.1f';

--- a/client/source/js/modules/d3-charts/scale-helpers.spec.coffee
+++ b/client/source/js/modules/d3-charts/scale-helpers.spec.coffee
@@ -5,24 +5,29 @@ define ['Source/modules/d3-charts/scale-helpers'], (scaleHelpers) ->
     describe 'evaluateTickFormat', ->
 
       it 'should choose a precesion of 3 decimal points for a range smaller than 0.01', ->
-        expect(scaleHelpers.evaluateTickFormat(0, 0.009)).toBe(',.3f')
-        expect(scaleHelpers.evaluateTickFormat(0.1, 0.1002)).toBe(',.3f')
-        expect(scaleHelpers.evaluateTickFormat(-0.001, -0.002)).toBe(',.3f')
+        expect(scaleHelpers.evaluateTickFormat(0, 0.009)).toBe('.3f')
+        expect(scaleHelpers.evaluateTickFormat(0.1, 0.1002)).toBe('.3f')
+        expect(scaleHelpers.evaluateTickFormat(-0.001, -0.002)).toBe('.3f')
 
       it 'should choose a precesion of 2 decimal points for a range smaller than 1', ->
-        expect(scaleHelpers.evaluateTickFormat(0, 0.9)).toBe(',.2f')
-        expect(scaleHelpers.evaluateTickFormat(0.1, 0.2)).toBe(',.2f')
-        expect(scaleHelpers.evaluateTickFormat(-0.1, -0.2)).toBe(',.2f')
+        expect(scaleHelpers.evaluateTickFormat(0, 0.9)).toBe('.2f')
+        expect(scaleHelpers.evaluateTickFormat(0.1, 0.2)).toBe('.2f')
+        expect(scaleHelpers.evaluateTickFormat(-0.1, -0.2)).toBe('.2f')
 
       it 'should choose a precesion of 1 decimal points for a range smaller than 10', ->
-        expect(scaleHelpers.evaluateTickFormat(0, 9)).toBe(',.1f')
-        expect(scaleHelpers.evaluateTickFormat(3, 4)).toBe(',.1f')
-        expect(scaleHelpers.evaluateTickFormat(-1, -2)).toBe(',.1f')
+        expect(scaleHelpers.evaluateTickFormat(0, 9)).toBe('.1f')
+        expect(scaleHelpers.evaluateTickFormat(3, 4)).toBe('.1f')
+        expect(scaleHelpers.evaluateTickFormat(-1, -2)).toBe('.1f')
 
-      it 'should choose a precesion of 0 decimal points for a range between 10 & 100,000', ->
-        expect(scaleHelpers.evaluateTickFormat(0, 11)).toBe(',.0f')
+      it 'should choose a precesion of 0 decimal points for a range between 10 & 10,000', ->
+        expect(scaleHelpers.evaluateTickFormat(0, 11)).toBe('.0f')
+        expect(scaleHelpers.evaluateTickFormat(0, 2014)).toBe('.0f')
+        expect(scaleHelpers.evaluateTickFormat(-1, -20)).toBe('.0f')
+
+      it 'should choose a precesion of 0 decimal points for a range between 10,000 & 100,000', ->
+        expect(scaleHelpers.evaluateTickFormat(0, 10001)).toBe(',.0f')
         expect(scaleHelpers.evaluateTickFormat(1000, 100000)).toBe(',.0f')
-        expect(scaleHelpers.evaluateTickFormat(-1, -20)).toBe(',.0f')
+        expect(scaleHelpers.evaluateTickFormat(-1, -20000)).toBe(',.0f')
 
       it 'should choose a custom formating for a range above 100,000', ->
         expect(scaleHelpers.evaluateTickFormat(0, 100001)).toBe('custom')

--- a/client/source/js/modules/d3-charts/scale-helpers.spec.coffee
+++ b/client/source/js/modules/d3-charts/scale-helpers.spec.coffee
@@ -4,6 +4,11 @@ define ['Source/modules/d3-charts/scale-helpers'], (scaleHelpers) ->
 
     describe 'evaluateTickFormat', ->
 
+      it 'should choose a precesion of 3 decimal points for a range smaller than 0.01', ->
+        expect(scaleHelpers.evaluateTickFormat(0, 0.009)).toBe(',.3f')
+        expect(scaleHelpers.evaluateTickFormat(0.1, 0.1002)).toBe(',.3f')
+        expect(scaleHelpers.evaluateTickFormat(-0.001, -0.002)).toBe(',.3f')
+
       it 'should choose a precesion of 2 decimal points for a range smaller than 1', ->
         expect(scaleHelpers.evaluateTickFormat(0, 0.9)).toBe(',.2f')
         expect(scaleHelpers.evaluateTickFormat(0.1, 0.2)).toBe(',.2f')


### PR DESCRIPTION
...0.01

Fixes for 2 cards:
https://trello.com/c/j613Ce71/484-fix-scale-for-low-ranges
https://trello.com/c/WmBJep5k/475-x-axis-on-graphs-on-the-optimization-page-should-be-years