### PR TITLE
Feature/503 titles are missing for pie charts in optimization

### DIFF
--- a/client/source/js/modules/analysis/optimization-ctrl.js
+++ b/client/source/js/modules/analysis/optimization-ctrl.js
@@ -177,7 +177,8 @@ define(['./module', 'angular', 'd3'], function (module, angular, d3) {
           right: 100,
           bottom: 20,
           left: 100
-        }
+        },
+        title: data.name
       };
 
       //TODO @NikGraph @DEvseev - make a stack chart now then pie.val is a combination of arrays (one per population)
@@ -218,14 +219,13 @@ define(['./module', 'angular', 'd3'], function (module, angular, d3) {
       var options = {
         legend: [],
         linesStyle: linesStyle,
-        title: 'Allocation'
+        title: data.name
       };
 
       //TODO @NikGraph @DEvseev - make a stack chart now then pie.val is a combination of arrays (one per population)
       graphData[0].axes = _(data.val).map(function (value, index) {
         return { value: value[0], axis: legend[index] };
       });
-      options.legend.push(data.name);
 
       return {
         'data': graphData,
@@ -255,7 +255,7 @@ define(['./module', 'angular', 'd3'], function (module, angular, d3) {
     /**
      * Returns a prepared chart object for a pie chart.
      */
-    var generateStackedBarChart = function(yData, xData, legend) {
+    var generateStackedBarChart = function(yData, xData, legend, title) {
       var graphData = [];
 
       var options = {
@@ -268,7 +268,8 @@ define(['./module', 'angular', 'd3'], function (module, angular, d3) {
         yAxis: {
           axisLabel: ''
         },
-        legend: legend
+        legend: legend,
+        title: title
       };
 
       graphData = _(xData).map(function (xValue, index) {
@@ -290,10 +291,12 @@ define(['./module', 'angular', 'd3'], function (module, angular, d3) {
       var charts = [];
 
       if (data.pie1) {
-        charts.push(generateStackedBarChart(data.pie1.val, xData, data.legend));
+        charts.push(generateStackedBarChart(data.pie1.val, xData, data.legend,
+          data.pie1.name));
       }
       if (data.pie2) {
-        charts.push(generateStackedBarChart(data.pie2.val, xData, data.legend));
+        charts.push(generateStackedBarChart(data.pie2.val, xData, data.legend,
+          data.pie2.name));
       }
 
       return charts;

--- a/client/source/js/modules/common/export-helpers-service.js
+++ b/client/source/js/modules/common/export-helpers-service.js
@@ -100,7 +100,7 @@ define(['angular', 'jquery', './svg-to-png', 'underscore'], function (angular, $
       if (!graph.data || !graph.options) return null;
 
       var exportable = {
-        name: graph.options.title || graph.title,
+        name: graph.options.title || 'Data',
         columns: []
       };
 
@@ -140,7 +140,7 @@ define(['angular', 'jquery', './svg-to-png', 'underscore'], function (angular, $
      */
     var linesExport = function (graph){
       var exportable = {
-        name: graph.options.title || graph.title,
+        name: graph.options.title || 'Data',
         columns: []
       };
 
@@ -181,7 +181,7 @@ define(['angular', 'jquery', './svg-to-png', 'underscore'], function (angular, $
      */
     var areasExport = function (graph){
       var exportable = {
-        name: graph.options.title || graph.title,
+        name: graph.options.title || 'Data',
         columns: []
       };
 
@@ -210,7 +210,7 @@ define(['angular', 'jquery', './svg-to-png', 'underscore'], function (angular, $
     var axesExport = function (graph){
       //x and y are not needed to be exported - they are just internal values to draw radar chart properly
       var exportable = {
-        name: graph.options.title,
+        name: graph.options.title || 'Data',
         columns: []
       };
 
@@ -234,7 +234,7 @@ define(['angular', 'jquery', './svg-to-png', 'underscore'], function (angular, $
     */
     var pieExport = function (graph){
       var exportable = {
-        name: graph.options.title || graph.title || "Allocation",
+        name: graph.options.title || 'Data',
         columns: []
       };
 
@@ -253,7 +253,7 @@ define(['angular', 'jquery', './svg-to-png', 'underscore'], function (angular, $
     */
     var stackedBarsExport = function (chart){
       var exportable = {
-        name: chart.options.title || chart.title || "Data",
+        name: chart.options.title,
         columns: []
       };
 

--- a/client/source/js/modules/common/save-graph-as-directive.js
+++ b/client/source/js/modules/common/save-graph-as-directive.js
@@ -107,7 +107,7 @@ define(['angular', 'jquery', 'underscore', 'saveAs', 'jsPDF', './svg-to-png', '.
             var exportable = exportHelpers.getExportableFrom(graphOrUndefined);
 
             if(exportable === null) { return exportHelpers.saySorry(); }
-            var title = graphOrUndefined.options.title || graphOrUndefined.title || "data";
+            var title = graphOrUndefined.options.title || 'Data';
             $http({url:'/api/project/export',
                   method:'POST',
                   data: exportable,

--- a/client/source/js/modules/d3-charts/d3-charts-service.js
+++ b/client/source/js/modules/d3-charts/d3-charts-service.js
@@ -426,7 +426,7 @@ define(['./module', 'd3', 'underscore', './scale-helpers'], function (module, d3
     function drawTitleAndLegend (svg, options, headerGroup) {
       var titleOffsetTop = 20;
 
-      if (options.hasTitle) {
+      if (options.hasTitle && !options.hideTitle) {
         var titleWidth = options.width - options.margin.left - options.margin.right;
 
         headerGroup.append('text')
@@ -530,7 +530,7 @@ define(['./module', 'd3', 'underscore', './scale-helpers'], function (module, d3
       options.hasLegend = !!options.legend;
 
       var titleOffset = 0;
-      if (options.hasTitle) {
+      if (options.hasTitle && !options.hideTitle) {
         titleOffset += 30;
       }
       options.margin.top += titleOffset;

--- a/client/source/js/modules/d3-charts/pie-chart-directive.js
+++ b/client/source/js/modules/d3-charts/pie-chart-directive.js
@@ -5,6 +5,8 @@ define(['./module'], function (module) {
     var svg;
 
     var drawGraph = function (data, options, rootElement) {
+      options = d3Charts.adaptOptions(options);
+
       // to prevent creating multiple graphs we want to remove the existing svg
       // element before drawing a new one.
       if (svg) {
@@ -28,6 +30,7 @@ define(['./module'], function (module) {
       var headerGroup = svg.append('g').attr('class', 'header_group');
 
       d3Charts.PieChart(chartGroup, chartSize, data.slices);
+      d3Charts.drawTitleAndLegend(svg, options, headerGroup);
     };
 
     return {

--- a/client/source/js/modules/model/cost-coverage-ctrl.js
+++ b/client/source/js/modules/model/cost-coverage-ctrl.js
@@ -73,7 +73,7 @@ define(['./module', 'underscore'], function (module, _) {
         return {
           name: item.name,
           acronym: acronym,
-          category: item.category, 
+          category: item.category,
           ccparams: $scope.all_programs[acronym].ccparams,
           ccplot: $scope.all_programs[acronym].ccplot
         };
@@ -128,21 +128,14 @@ define(['./module', 'underscore'], function (module, _) {
 
       var graph = {
         options: getLineScatterOptions({
-          width: 300,
-          height: 200,
-          margin: {
-            top: 20,
-            right: 15,
-            bottom: 40,
-            left: 60
-          },
-          linesStyle: ['__blue', '__black __dashed', '__black __dashed']
+          linesStyle: ['__blue', '__black __dashed', '__black __dashed'],
+          title: graphData.title,
+          hideTitle: true
         }, graphData.xlabel, graphData.ylabel),
         data: {
           lines: [],
           scatter: []
-        },
-        title: graphData.title
+        }
       };
 
       // quit if data is empty - empty graph placeholder will be displayed
@@ -184,7 +177,7 @@ define(['./module', 'underscore'], function (module, _) {
      */
     var prepareCostCoverageGraph = function (data) {
       var graph = {
-        options: getLineScatterOptions({}, data.xlabel, data.ylabel),
+        options: getLineScatterOptions({ hideTitle: true }, data.xlabel, data.ylabel),
         data: {
           // there is a single line for that type
           lines: [[]],
@@ -224,7 +217,7 @@ define(['./module', 'underscore'], function (module, _) {
     var prepareGraphsOfType = function (data, type) {
       if (type === 'plotdata_cc') {
         $scope.ccGraph = prepareCostCoverageGraph(data);
-        $scope.ccGraph.title = $scope.displayedProgram.name;
+        $scope.ccGraph.options.title = $scope.displayedProgram.name;
       } else if (type === 'plotdata' || type === 'plotdata_co') {
         _(data).each(function (graphData) {
           $scope.graphs[type].push(setUpPlotdataGraph(graphData));
@@ -328,7 +321,7 @@ define(['./module', 'underscore'], function (module, _) {
      */
     var retrieveAndUpdateGraphs = function (model) {
       // validation on Cost-coverage curve plotting options
-      if (!areCCParamsValid(model.ccparams)){ 
+      if (!areCCParamsValid(model.ccparams)){
         return;
       }
 
@@ -491,13 +484,13 @@ define(['./module', 'underscore'], function (module, _) {
 
       if ( $scope.ccGraph) {
         $scope.chartsForDataExport.push($scope.ccGraph);
-        $scope.titlesForChartsExport.push($scope.ccGraph.title);
+        $scope.titlesForChartsExport.push($scope.ccGraph.options.title);
       }
 
       var charts = _(_.zip($scope.graphs.plotdata, $scope.graphs.plotdata_co)).flatten();
       _( charts ).each(function (chart,index) {
         $scope.chartsForDataExport.push(chart);
-        $scope.titlesForChartsExport.push(chart.title);
+        $scope.titlesForChartsExport.push(chart.options.title);
       });
     };
 

--- a/client/source/js/modules/model/cost-coverage.html
+++ b/client/source/js/modules/model/cost-coverage.html
@@ -111,7 +111,7 @@
       </div>
 
       <div class="section" ng-if="graphs.plotdata.length" ng-repeat="chart in graphs.plotdata">
-        <h2 class="section">{{ chart.title }}</h2>
+        <h2 class="section">{{ chart.options.title }}</h2>
 
         <div class="section elastic">
           <div class="elastic_col __shrink" style="width: 320px">


### PR DESCRIPTION
https://trello.com/c/yF0dQsii/503-titles-are-missing-for-pie-charts-in-optimization

In addition to show the titles properly for pie, radar & stacked charts I refactored titles used in cost coverage.

Before we used chart.title & chart.options.title. chart.title wasn't used do display in the chart, but only for the data export. I replaced it with chart.options.title & chart.options.hideTitle to remove this obscurity.