### PR TITLE
Feature/546 typeerror cannot read property x of undefined

### DIFF
--- a/client/source/js/modules/d3-charts/d3-charts-service.js
+++ b/client/source/js/modules/d3-charts/d3-charts-service.js
@@ -222,9 +222,25 @@ define(['./module', 'd3', 'underscore', './scale-helpers'], function (module, d3
       };
 
       this.draw = function (dataset) {
-        exit(dataset);
-        transition(dataset);
-        enter(dataset);
+        if (dataset.length > 1) {
+          exit(dataset);
+          transition(dataset);
+          enter(dataset);
+        } else if (dataset.length === 1) {
+          // draw a point in case there is only one entry
+          chart.selectAll('circle.' + uniqClassName)
+            .data(dataset)
+            .enter()
+            .append('circle')
+            .attr('cx', function (d) {
+              return xScale(d[0]);
+            })
+            .attr('cy', function (d) {
+              return yScale(d[1]);
+            })
+            .attr('class', ['line ', colorClass, uniqClassName].join(' '))
+            .attr('r', 3);
+        }
       };
 
       this.dispose = function () {

--- a/client/source/js/modules/d3-charts/line-scatter-directive.js
+++ b/client/source/js/modules/d3-charts/line-scatter-directive.js
@@ -52,8 +52,7 @@ define(['./module', './scale-helpers', 'angular'], function (module, scaleHelper
       };
 
       var scatterDataExists = (data.scatter && (data.scatter.length > 0));
-      // data.lines[0].length >1 to escape explosion here.
-      var linesDataExists = (data.lines && data.lines.length > 0 && (data.lines[0].length > 1));
+      var linesDataExists = (data.lines && data.lines.length > 0);
 
       var hasValidMin = function(domain) {
         return (domain[0]!==null && !isNaN(domain[0]));
@@ -99,7 +98,7 @@ define(['./module', './scale-helpers', 'angular'], function (module, scaleHelper
        
       // normalizing all graphs scales to include maximum possible x and y
       _(graphsScales).each(function (scale) {
-        scale.y.domain([0, yMax]);
+        scale.y.domain([yMin, yMax]);
         scale.x.domain([Math.floor(xMin), scaleHelpers.flexCeil(xMax)]);
       });
 

--- a/client/source/js/modules/d3-charts/line-scatter-directive.js
+++ b/client/source/js/modules/d3-charts/line-scatter-directive.js
@@ -95,7 +95,14 @@ define(['./module', './scale-helpers', 'angular'], function (module, scaleHelper
         if(hasValidMin(y_domain)) { yMin = Math.min(yMin, y_domain[0]); }
         if(hasValidMin(x_domain)) { xMin = Math.min(xMin, x_domain[0]); }
       }
-       
+
+      // to make it visually appealing in case there is a point but no line
+      // the data point is centered
+      if (xMin == xMax) {
+        xMin = xMin - 1;
+        xMax = xMax + 1;
+      }
+
       // normalizing all graphs scales to include maximum possible x and y
       _(graphsScales).each(function (scale) {
         scale.y.domain([yMin, yMax]);

--- a/client/source/js/modules/d3-charts/scale-helpers.js
+++ b/client/source/js/modules/d3-charts/scale-helpers.js
@@ -34,8 +34,10 @@ define(['d3'], function (d3) {
    * 2.4 -> 3
    * 0.00242 -> 0.003
    * 0.041 -> 0.05
+   * 0 -> 0
    */
   var flexCeil = function(value) {
+    if (value === 0) return 0;
     if (value >= 1.0) return Math.ceil(value);
     var multi=1.0;
     while (value < 1.0){

--- a/client/source/js/modules/d3-charts/scale-helpers.spec.coffee
+++ b/client/source/js/modules/d3-charts/scale-helpers.spec.coffee
@@ -53,3 +53,4 @@ define ['Source/modules/d3-charts/scale-helpers'], (scaleHelpers) ->
         expect(scaleHelpers.flexCeil(0.2)).toBe(0.2)
         expect(scaleHelpers.flexCeil(0.023)).toBe(0.03)
         expect(scaleHelpers.flexCeil(0.000654)).toBe(0.0007)
+        expect(scaleHelpers.flexCeil(0)).toBe(0)


### PR DESCRIPTION
https://trello.com/c/6r5KX3jp/546-typeerror-cannot-read-property-x-of-undefined-is-shown-when-checking-for-existing-optimization
https://trello.com/c/RK5HmFia/545-empty-graph-frame-at-optimization-page

The browsers crashed, because flexCeil was going into an endless loop for the value 0.
In addition I made some modification to make line charts still visually appealing even if there is only one entry for a line.

![screen shot 2015-02-05 at 11 51 51](https://cloud.githubusercontent.com/assets/223045/6058195/d7c918a8-ad2d-11e4-99c4-81d5ad3d4b3e.png)
